### PR TITLE
Phase 6: Integrations — chezmoi per-host templates + CLAUDE.md symlink

### DIFF
--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -1,0 +1,42 @@
+{{/*
+.chezmoi.yaml.tmpl — host-detection + age multi-recipient encryption envelope.
+
+Host detection cascade (matches Phase 6 RESEARCH Spec 4):
+  - darwin → macos
+  - linux + DEVPOD env → devpod (headless container)
+  - linux + IOS env → ios (Working Copy folder-sync on iPadOS/iOS)
+  - else → linux-other (fallback; no vault-ai plugin install)
+
+Encryption: age with multi-recipient recipients (primary + escrow) per
+vault-ai ADR-sec-02 (chezmoi + age multi-recipient primary; git-crypt
+REJECTED). Two recipients give single-key-loss resilience — any one of
+the N keys can decrypt. Primary = operator's daily key. Escrow = YubiKey
+or offline offsite storage.
+
+Cross-refs: workspace-meta/.planning/phases/06-integrations/06-CONTEXT.md
+D-07 (chezmoi+age multi-recipient), D-20 (per-host templates);
+vault-ai/docs/adr/adr-sec-02-secrets-stack.md §Multi-recipient age;
+vault-ai/docs/adr/adr-ai-06-mcp-auth.md §VAULT_AI_TOKEN provisioning.
+*/ -}}
+{{- $host := "" -}}
+{{- if eq .chezmoi.os "darwin" -}}{{- $host = "macos" -}}
+{{- else if env "DEVPOD" -}}{{- $host = "devpod" -}}
+{{- else if env "IOS" -}}{{- $host = "ios" -}}
+{{- else -}}{{- $host = "linux-other" -}}{{- end }}
+
+data:
+  host: "{{ $host }}"
+  vault_path: {{- if eq $host "macos" }} "/Users/{{ env "USER" }}/projects/vault-ai"
+              {{- else if eq $host "devpod" }} "/home/vscode/projects/vault-ai"
+              {{- else if eq $host "ios" }} "/private/var/mobile/Containers/Shared/AppGroup/Obsidian/vault-ai"
+              {{- else }} "/home/{{ env "USER" }}/projects/vault-ai"{{- end }}
+
+# Multi-recipient age — primary + escrow; either key decrypts (ADR-sec-02).
+# Replace placeholder pubkeys at `chezmoi init` time with the operator's real
+# age public keys. The `age1...` prefix is verified by age 1.2.x at apply.
+encryption: age
+age:
+  identity: "~/.age/primary.key"
+  recipients:
+    - "age1primaryplaceholder0000000000000000000000000000000000pkey"
+    - "age1escrowplaceholder00000000000000000000000000000000000pkey"

--- a/dot_config/chezmoi/templates/obsidian.devpod.tmpl
+++ b/dot_config/chezmoi/templates/obsidian.devpod.tmpl
@@ -1,0 +1,31 @@
+# DevPod host chezmoi template (headless)
+# Applies when: {{ env "DEVPOD" }} is set
+# Plugins: Git + schema-tooling only (minimal surface for CI-adjacent
+#   validation; no GUI-dependent plugins since DevPod is headless).
+# Theme: obsidian default (no Minimal snippets — headless, no render).
+# Sync: git CLI from shell (`git pull` + `git push` directly).
+# VAULT_AI_TOKEN: age-decrypt at shell bootstrap per ADR-ai-06.
+#
+# Cross-refs:
+#   workspace-meta/.planning/phases/06-integrations/06-CONTEXT.md D-20
+#     (per-host templates);
+#   vault-ai/docs/adr/adr-sec-02-secrets-stack.md §per-host chezmoi;
+#   vault-ai/_tooling/validator/tests/fixtures/hosts/devpod.env (Plan 05
+#     Task 1 fixture — matches this template's field values).
+
+obsidian_plugins:
+  - obsidian-git
+  - _schema_tooling
+obsidian_theme: "obsidian"
+sync_method: "git-cli"
+vault_path: "{{ .vault_path }}"
+snippets_enabled: false
+vault_ai_token_source: "age-decrypt-at-bootstrap"
+
+# FOLDED TODO (Phase 6 D-20 + 06-CONTEXT §Folded Todos):
+# Symlink ~/projects/CLAUDE.md -> workspace-meta/CLAUDE.md so the root
+# CLAUDE.md survives container rebuild. Implementation lives at:
+#   dotfiles/run_onchange_after_symlink_claude_md.sh.tmpl
+# Hook runs on every `chezmoi apply` AND on content change of the script
+# body. See the hook file for the idempotent `ln -sfn` invocation.
+claude_md_symlink: "{{ .chezmoi.homeDir }}/projects/CLAUDE.md -> {{ .chezmoi.homeDir }}/projects/workspace-meta/CLAUDE.md"

--- a/dot_config/chezmoi/templates/obsidian.ios.tmpl
+++ b/dot_config/chezmoi/templates/obsidian.ios.tmpl
@@ -1,0 +1,34 @@
+# iOS host chezmoi template (offline-only, capture-only)
+# Applies when: env "IOS" is set.
+# Role: mobile capture via Working Copy folder-sync per ADR-flow-01
+#   (Amsterdam capture SOP, Phase 5 forward-ref). Desktop-side triage
+#   handles MCP calls post-push; iOS is never an MCP client.
+# Plugins: Git + QuickAdd only (minimal for mobile performance).
+# Theme: Minimal (no snippets — CSS rendering costly on mobile; ADR-visual-02
+#   mobile-ruleset mitigates but offline-only mode disables snippets entirely).
+# Sync: Working Copy folder-sync only (PRIV-02 mitigation — iOS git CLI
+#   absent on standard devices; Working Copy is the sole iOS git client).
+# Obsidian-Git auto-commit DISABLED (Phase 2 plugin lockfile CAP-01
+#   mitigation — mobile auto-commit + desktop autosave-off is dangerous).
+#
+# **No MCP bearer on iOS (PRIV-02):** iOS hosts carry no MCP bearer token.
+# iOS is capture-only; MCP calls originate from desktop AFTER the captured
+# notes are git-pushed upstream. This template intentionally OMITS the
+# vault_ai_token_source field — the grep guardrail asserts zero matches for
+# the bearer-token identifier string in this file.
+#
+# Cross-refs:
+#   workspace-meta/.planning/phases/06-integrations/06-CONTEXT.md D-20;
+#   vault-ai/docs/adr/adr-sec-02-secrets-stack.md §iOS minimal-plugins;
+#   vault-ai/_tooling/validator/tests/fixtures/hosts/ios.env (fixture
+#     matching this template's field values).
+
+obsidian_plugins:
+  - obsidian-git
+  - quickadd
+obsidian_theme: "minimal"
+obsidian_snippets: []
+sync_method: "working-copy-folder"
+vault_path: "{{ .vault_path }}"
+snippets_enabled: false
+# NO vault_ai_token_source field (PRIV-02): iOS has no MCP access.

--- a/dot_config/chezmoi/templates/obsidian.macos.tmpl
+++ b/dot_config/chezmoi/templates/obsidian.macos.tmpl
@@ -1,0 +1,40 @@
+# macOS host chezmoi template (interactive)
+# Applies when: .chezmoi.os == "darwin"
+# Plugins: Full 8 (Dataview, Templater, Metadata Menu, Git, Style Settings,
+#   QuickAdd, Advanced URI, Iconize) per ADR-meth-01 + Phase 2 plugin lockfile
+#   (NTYPE-16).
+# Theme: Minimal (Kepano) v8.1.7 pinned per ADR-visual-02; 5 snippets loaded
+#   (_variables, anytype-card, formal-adr, minimal-zettel, dashboard-project).
+# Sync: Obsidian-Git with autosave OFF (CAP-01 Phase 5 D-32 mobile-sync
+#   conflict mitigation — manual commit cadence on desktop).
+# VAULT_AI_TOKEN: Keychain first; fallback to age-decrypt at shell init
+#   (ADR-sec-02 secondary path).
+#
+# Cross-refs:
+#   workspace-meta/.planning/phases/06-integrations/06-CONTEXT.md D-20
+#     (per-host templates);
+#   vault-ai/docs/adr/adr-sec-02-secrets-stack.md §Multi-recipient age;
+#   vault-ai/docs/adr/adr-visual-02-theme-and-font-lockfile.md;
+#   vault-ai/_tooling/validator/tests/fixtures/hosts/macos.env (fixture
+#     matching this template's field values).
+
+obsidian_plugins:
+  - dataview
+  - templater
+  - metadata-menu
+  - obsidian-git
+  - obsidian-style-settings
+  - quickadd
+  - advanced-uri
+  - obsidian-iconize
+obsidian_theme: "minimal"
+obsidian_snippets:
+  - _variables
+  - anytype-card
+  - formal-adr
+  - minimal-zettel
+  - dashboard-project
+sync_method: "obsidian-git-autosave-off"
+vault_path: "{{ .vault_path }}"
+snippets_enabled: true
+vault_ai_token_source: "keychain-or-age"

--- a/run_onchange_after_symlink_claude_md.sh.tmpl
+++ b/run_onchange_after_symlink_claude_md.sh.tmpl
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# chezmoi run_onchange hook — FOLDED TODO (Phase 6 D-20):
+# Ensure ~/projects/CLAUDE.md symlink to workspace-meta/CLAUDE.md survives
+# container rebuild (DevPod) or host reinstall (macOS). chezmoi re-runs this
+# script on every `chezmoi apply` AND on content change of the script body;
+# the idempotent `ln -sfn` refresh keeps the symlink healthy without side
+# effects when already correct.
+#
+# Resolves the long-standing todo: "Symlink root CLAUDE.md from
+# workspace-meta to survive container rebuild" (PROJECT.md §Pending Todos;
+# Phase 6 CONTEXT §Folded Todos).
+#
+# Cross-refs:
+#   workspace-meta/.planning/phases/06-integrations/06-CONTEXT.md §Folded
+#     Todos (root CLAUDE.md symlink);
+#   workspace-meta/CLAUDE.md (the canonical target file).
+
+set -euo pipefail
+
+TARGET="{{ .chezmoi.homeDir }}/projects/workspace-meta/CLAUDE.md"
+LINK="{{ .chezmoi.homeDir }}/projects/CLAUDE.md"
+
+# If the target is absent we log a warning and exit 0 rather than failing.
+# Rationale: workspace-meta may not be cloned on every host (iOS does not
+# host workspace-meta); the symlink only matters on desktop+devpod hosts
+# where workspace-meta is cloned alongside the sibling repos.
+if [ ! -f "$TARGET" ]; then
+  printf 'WARN: %s not found; skipping CLAUDE.md symlink\n' "$TARGET" >&2
+  exit 0
+fi
+
+# Idempotent refresh: `ln -sfn` replaces the symlink if present, creates it
+# otherwise. -n prevents dereferencing the existing target when the link
+# points at a directory (pathological case but cheap to guard against).
+ln -sfn "$TARGET" "$LINK"
+
+# Verify: readlink -f resolves the symlink to an absolute canonical path on
+# both sides; if they differ, the symlink is broken or points elsewhere.
+if [ "$(readlink -f "$LINK")" != "$(readlink -f "$TARGET")" ]; then
+  printf 'FAIL: CLAUDE.md symlink verification failed: %s -> %s\n' \
+    "$LINK" "$TARGET" >&2
+  exit 1
+fi
+
+printf 'OK: CLAUDE.md symlink intact: %s -> %s\n' "$LINK" "$TARGET"


### PR DESCRIPTION
## Summary

**Phase 6 / v2.0 Vault-AI Architecture** — dotfiles surface of the integrations milestone.

Adds chezmoi per-host Obsidian templates (DevPod headless / macOS interactive / iOS capture-only) with age multi-recipient encryption support, plus a `run_onchange` hook that symlinks the root `~/projects/CLAUDE.md` into the workspace (closes D-20 folded todo from prior milestones).

## Changes

**5 commits:**
- `102bc72` feat(chezmoi): add .chezmoi.yaml.tmpl host-detection + age multi-recipient
- `0f3e88f` feat(chezmoi): add obsidian.devpod.tmpl headless template
- `04d3aa1` feat(chezmoi): add obsidian.macos.tmpl interactive template
- `4ee812f` feat(chezmoi): add obsidian.ios.tmpl capture-only template
- `34e76c6` feat(chezmoi): add run_onchange CLAUDE.md symlink hook (D-20 folded todo)

## Requirements addressed

- **INT-13** — chezmoi dotfiles templates per host (DevPod/macOS/iOS)
- **D-20** (folded) — root CLAUDE.md symlink

## Context

Part of Phase 6 "Integrations" in v2.0 milestone. Companion PRs in workspace-meta, vault-ai, workflow-kit, workspace-cli.

## Test plan

- [x] All 3 templates render on host detection
- [x] `run_onchange_after_symlink_claude_md.sh.tmpl` idempotent
- [ ] Manual: apply on iPad (iOS template) — owner verification step