### PR TITLE
chore(gitignore): ignore state/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swp
 *.swo
 *~
+
+# Session logs (gsd-tools / Claude Code hook-generated)
+state/


### PR DESCRIPTION
Add `state/` to .gitignore to stop tracking hook-generated runtime logs.