### PR TITLE
Recipients SoT + multi-recipient escrow activation

### DIFF
--- a/.age-recipients.yaml
+++ b/.age-recipients.yaml
@@ -1,0 +1,30 @@
+# .age-recipients.yaml — canonical source-of-truth for chezmoi-managed age recipients.
+#
+# Plan 14-15 closes 14-REVIEW WR-05: hardcoded `age1...` strings inside
+# `.chezmoi.yaml.tmpl` left no in-file pointer back to which host owned which
+# key, so an operator rotating the macbook escrow key edited an opaque body
+# and discovered mismatches only at next-decrypt time.
+#
+# This file is the SINGLE source of truth for the active recipient set.
+# `.chezmoi.yaml.tmpl` reads it via `include + fromYaml` and renders the
+# `recipients:` list at apply time. `scripts/verify-recipients.sh` does a
+# structural compare of `active[].pubkey` against `docs/AUTHORIZED-HOSTS.md`
+# active tier, so a typo or stale entry trips before the next chezmoi apply.
+#
+# Operator rotation procedure (post-Plan 14-15):
+#   1. Edit `.age-recipients.yaml` — change pubkey for the rotating host.
+#   2. Update `docs/AUTHORIZED-HOSTS.md` row matching the host name.
+#   3. Run `chezmoi apply --dry-run` — verify no diff outside the recipient.
+#   4. `bash scripts/verify-recipients.sh` — exit 0 confirms invariant holds.
+#   5. Commit + push. (Public repo: no AI/vendor attribution per ADR-009 scope.)
+#
+# Bidirectional invariant: `scripts/verify-recipients.sh` asserts
+# `.age-recipients.yaml::active[].pubkey` matches `docs/AUTHORIZED-HOSTS.md`
+# active-tier rows.
+active:
+  - name: devpod-primary
+    role: daily-use
+    pubkey: age1wa2cuua5lfj26he6qrjrywdvqk3twvyhevfngfzy76ztxj5ex3xs454cgp
+  - name: macbook-escrow
+    role: NIST-SP-800-57-physically-separate
+    pubkey: age1kre65j3v87d0cru8tkj6g6s2823yncw78qcvu6y2m7h8umxxny6qpupzvq

--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -1,6 +1,15 @@
 {{/*
 .chezmoi.yaml.tmpl — host-detection + age multi-recipient encryption envelope.
 
+Plan 14-15 (closes 14-REVIEW WR-05 + IN-05):
+  - Recipients now sourced from `.age-recipients.yaml` via `include + fromYaml`
+    rather than hardcoded `age1...` strings (single source of truth, audit-trail
+    friendly diff: rotation shows `name: <host>` changed pubkey, not just an
+    opaque substring).
+  - Boot-time fail-loud on conflicting host signals (`DEVPOD` env set on darwin,
+    `IOS` env set on linux/darwin, etc.) — operator misconfiguration must
+    surface BEFORE chezmoi apply mutates state.
+
 Host detection cascade (matches Phase 6 RESEARCH Spec 4):
   - darwin → macos
   - linux + DEVPOD env → devpod (headless container)
@@ -16,8 +25,18 @@ or offline offsite storage.
 Cross-refs: workspace-meta/.planning/phases/06-integrations/06-CONTEXT.md
 D-07 (chezmoi+age multi-recipient), D-20 (per-host templates);
 vault-ai/docs/adr/adr-sec-02-secrets-stack.md §Multi-recipient age;
-vault-ai/docs/adr/adr-ai-06-mcp-auth.md §VAULT_AI_TOKEN provisioning.
+vault-ai/docs/adr/adr-ai-06-mcp-auth.md §VAULT_AI_TOKEN provisioning;
+.age-recipients.yaml (Plan 14-15 SoT).
 */ -}}
+{{- /* Plan 14-15 / 14-REVIEW IN-05: fail-loud on conflicting host signals.
+       DEVPOD set on darwin or IOS set on linux/darwin = operator misconfigured
+       something; refuse to render rather than route to the wrong vault path. */ -}}
+{{- if and (env "DEVPOD") (eq .chezmoi.os "darwin") -}}
+{{- fail "Plan 14-15 / IN-05: DEVPOD env var set on darwin host — host detection ambiguous. Unset DEVPOD or run on Linux." -}}
+{{- end -}}
+{{- if and (env "IOS") (ne .chezmoi.os "linux") -}}
+{{- fail "Plan 14-15 / IN-05: IOS env var set on non-linux host — host detection ambiguous. Unset IOS or run on the iOS Working Copy host." -}}
+{{- end -}}
 {{- $host := "" -}}
 {{- if eq .chezmoi.os "darwin" -}}{{- $host = "macos" -}}
 {{- else if env "DEVPOD" -}}{{- $host = "devpod" -}}
@@ -32,19 +51,15 @@ data:
               {{- else }} "/home/{{ env "USER" }}/projects/vault-ai"{{- end }}
 
 # Multi-recipient age — primary + escrow; either key decrypts (ADR-sec-02).
-# Recipients list is operator-curated against docs/AUTHORIZED-HOSTS.md
-# (CONTEXT.md D-07); the `age1...` prefix is verified by age 1.2.x at apply.
+# Recipients are sourced from `.age-recipients.yaml` (single source of truth,
+# audit-trail friendly per Plan 14-15 / WR-05). `scripts/verify-recipients.sh`
+# enforces the bidirectional invariant against `docs/AUTHORIZED-HOSTS.md` on
+# every commit and in CI.
+{{- $recipients := (include ".age-recipients.yaml" | fromYaml) }}
 encryption: age
 age:
   identity: "~/.age/primary.key"
-  # Recipients populated from docs/AUTHORIZED-HOSTS.md active tier
-  # (CONTEXT.md D-07). Each entry below MUST correspond to an
-  # `active`-tagged row in that document; scripts/verify-recipients.sh enforces
-  # the bidirectional invariant on every commit and in CI.
-  #
-  # - devpod (primary): DevPod headless container, daily-use age key
-  # - macbook (escrow): operator's macOS workstation, physically-separate per
-  #   NIST SP 800-57 §5.5.2 (single-key-loss resilience)
   recipients:
-    - "age1wa2cuua5lfj26he6qrjrywdvqk3twvyhevfngfzy76ztxj5ex3xs454cgp"
-    - "age1kre65j3v87d0cru8tkj6g6s2823yncw78qcvu6y2m7h8umxxny6qpupzvq"
+{{- range $recipients.active }}
+    - "{{ .pubkey }}"  # {{ .name }} — {{ .role }}
+{{- end }}

--- a/.chezmoi.yaml.tmpl
+++ b/.chezmoi.yaml.tmpl
@@ -37,13 +37,14 @@ data:
 encryption: age
 age:
   identity: "~/.age/primary.key"
-  # OPERATOR-FILL: see docs/AUTHORIZED-HOSTS.md for the canonical authorized-host
-  # allowlist (CONTEXT.md D-07). Each entry below MUST correspond to an
+  # Recipients populated from docs/AUTHORIZED-HOSTS.md active tier
+  # (CONTEXT.md D-07). Each entry below MUST correspond to an
   # `active`-tagged row in that document; scripts/verify-recipients.sh enforces
   # the bidirectional invariant on every commit and in CI.
   #
-  # Add the operator-real public keys here (one quoted string per `- "ageXXX"`
-  # line) AFTER running `age-keygen -y ~/.age/primary.key` on each authorized
-  # host (DevPod, MacBook). verify-recipients.sh will FAIL until real pubkeys
-  # are added, which is the intended gate.
-  recipients: []
+  # - devpod (primary): DevPod headless container, daily-use age key
+  # - macbook (escrow): operator's macOS workstation, physically-separate per
+  #   NIST SP 800-57 §5.5.2 (single-key-loss resilience)
+  recipients:
+    - "age1wa2cuua5lfj26he6qrjrywdvqk3twvyhevfngfzy76ztxj5ex3xs454cgp"
+    - "age1kre65j3v87d0cru8tkj6g6s2823yncw78qcvu6y2m7h8umxxny6qpupzvq"

--- a/docs/AUTHORIZED-HOSTS.md
+++ b/docs/AUTHORIZED-HOSTS.md
@@ -15,8 +15,8 @@ The invariant is enforced bidirectionally by `scripts/verify-recipients.sh` — 
 
 | hostname | role | pubkey | fingerprint | provisioned | host_type | tag |
 |----------|------|--------|-------------|-------------|-----------|-----|
-| devpod | primary | OPERATOR-FILL-DEVPOD-PUBKEY-AGE1-XXX...XXX | XXXXXXXX | 2026-05-03 | DevPod | pending |
-| macbook | primary | OPERATOR-FILL-MACBOOK-PUBKEY-AGE1-XXX...XXX | XXXXXXXX | 2026-05-03 | macOS | pending |
+| devpod | primary | age1wa2cuua5lfj26he6qrjrywdvqk3twvyhevfngfzy76ztxj5ex3xs454cgp | xs454cgp | 2026-05-04 | DevPod | active |
+| macbook | escrow | age1kre65j3v87d0cru8tkj6g6s2823yncw78qcvu6y2m7h8umxxny6qpupzvq | 6qpupzvq | 2026-05-04 | macOS | active |
 
 ## Retired Hosts (kept for audit trail; NOT compared by verify script)
 

--- a/scripts/verify-recipients.sh
+++ b/scripts/verify-recipients.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 # Source: CONTEXT.md D-07 + D-10. Bash-only per workspace CLAUDE.md.
 #
-# verify-recipients.sh -- bidirectional diff between:
-#   1. recipients: list in .chezmoi.yaml.tmpl
+# verify-recipients.sh -- bidirectional structural diff between:
+#   1. .age-recipients.yaml::active[].pubkey  (Plan 14-15 SoT — committed,
+#      audit-trail friendly with name + role + pubkey per entry)
 #   2. active-tagged hosts in docs/AUTHORIZED-HOSTS.md
 # Exit 0 on equality; exit 1 with human-readable diff on mismatch.
 #
+# Plan 14-15 (closes 14-REVIEW WR-05) replaced the prior regex-on-.tmpl
+# extraction path with a structural compare against `.age-recipients.yaml`
+# (single source of truth). The bash-only invariant (workspace CLAUDE.md
+# non-negotiable) is preserved: yq is acceptable here because this script
+# runs from CI / operator command line, NOT from a pre-commit hook.
+#
 # Env-var overrides (used by tests):
-#   CHEZMOI_TMPL          -- path to .chezmoi.yaml.tmpl
-#                            (default: $REPO_ROOT/.chezmoi.yaml.tmpl)
+#   DOTFILES_REPO         -- override the repo root lookup
+#                            (default: detected via `git rev-parse` or pwd)
+#   RECIPIENTS_YAML       -- path to .age-recipients.yaml SoT
+#                            (default: $DOTFILES_REPO/.age-recipients.yaml)
 #   AUTHORIZED_HOSTS_MD   -- path to AUTHORIZED-HOSTS.md
-#                            (default: $REPO_ROOT/docs/AUTHORIZED-HOSTS.md)
+#                            (default: $DOTFILES_REPO/docs/AUTHORIZED-HOSTS.md)
 #
 # AWK FIELD INDICES (locked per Phase 12 Plan 12-03 W2):
 # Table format: `| hostname | role | pubkey | fingerprint | provisioned | host_type | tag |`
@@ -19,22 +28,27 @@
 
 set -euo pipefail
 
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-TMPL="${CHEZMOI_TMPL:-$REPO_ROOT/.chezmoi.yaml.tmpl}"
+if [ -n "${DOTFILES_REPO:-}" ]; then
+  REPO_ROOT="$DOTFILES_REPO"
+else
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+RECIPIENTS_YAML="${RECIPIENTS_YAML:-$REPO_ROOT/.age-recipients.yaml}"
 ALLOWLIST="${AUTHORIZED_HOSTS_MD:-$REPO_ROOT/docs/AUTHORIZED-HOSTS.md}"
 
-[ -f "$TMPL" ] || { echo "FAIL: $TMPL not found" >&2; exit 1; }
+if ! command -v yq >/dev/null 2>&1; then
+  echo "FAIL: yq not installed (need Mike Farah v4 — https://github.com/mikefarah/yq)" >&2
+  exit 2
+fi
+
+[ -f "$RECIPIENTS_YAML" ] || { echo "FAIL: $RECIPIENTS_YAML not found" >&2; exit 1; }
 [ -f "$ALLOWLIST" ] || { echo "FAIL: $ALLOWLIST not found" >&2; exit 1; }
 
-# Extract recipients from .chezmoi.yaml.tmpl YAML block.
-# State machine: enter on `recipients:`, emit pubkey lines, exit on next non-indented key.
-template_recipients=$(awk '
-  /^[[:space:]]*recipients:[[:space:]]*$/ { in_block=1; next }
-  in_block && /^[[:space:]]*-[[:space:]]+"age1[^"]+"[[:space:]]*$/ {
-    match($0, /"age1[^"]+"/); pk = substr($0, RSTART+1, RLENGTH-2); print pk; next
-  }
-  in_block && /^[a-zA-Z]/ { in_block=0 }
-' "$TMPL" | sort -u)
+# Extract active pubkeys from SoT YAML (Plan 14-15 canonical extraction).
+sot_keys=$(yq -e '.active[].pubkey' "$RECIPIENTS_YAML" 2>/dev/null | sort -u) || {
+  echo "FAIL: $RECIPIENTS_YAML missing .active[].pubkey entries" >&2
+  exit 1
+}
 
 # Extract active-tagged pubkeys from docs/AUTHORIZED-HOSTS.md.
 # Table format (D-07): | hostname | role | pubkey | fingerprint | provisioned | host_type | tag |
@@ -51,20 +65,24 @@ allowlist_active=$(awk -F '|' '
 ' "$ALLOWLIST" | sort -u)
 
 # Bidirectional diff via comm.
-orphan_in_template=$(comm -23 <(echo "$template_recipients") <(echo "$allowlist_active") | grep -v '^$' || true)
-missing_from_template=$(comm -13 <(echo "$template_recipients") <(echo "$allowlist_active") | grep -v '^$' || true)
+orphan_in_sot=$(comm -23 <(echo "$sot_keys") <(echo "$allowlist_active") | grep -v '^$' || true)
+missing_from_sot=$(comm -13 <(echo "$sot_keys") <(echo "$allowlist_active") | grep -v '^$' || true)
 
 fail=0
-if [ -n "$orphan_in_template" ]; then
+if [ -n "$orphan_in_sot" ]; then
   printf 'FAIL: orphan recipients in %s (not in %s active tier):\n%s\n\n' \
-    "$TMPL" "$ALLOWLIST" "$orphan_in_template" >&2
+    "$RECIPIENTS_YAML" "$ALLOWLIST" "$orphan_in_sot" >&2
   fail=1
 fi
-if [ -n "$missing_from_template" ]; then
+if [ -n "$missing_from_sot" ]; then
   printf 'FAIL: active hosts missing from %s (declared active in %s but no recipient):\n%s\n\n' \
-    "$TMPL" "$ALLOWLIST" "$missing_from_template" >&2
+    "$RECIPIENTS_YAML" "$ALLOWLIST" "$missing_from_sot" >&2
   fail=1
 fi
-[ $fail -eq 0 ] && printf 'OK: recipients list matches AUTHORIZED-HOSTS.md active tier (%d entries)\n' \
-  "$(echo "$template_recipients" | grep -c . || true)"
+
+if [ $fail -eq 0 ]; then
+  count=$(echo "$sot_keys" | grep -c . || true)
+  printf 'OK: recipients SoT (%s) matches AUTHORIZED-HOSTS.md active tier (%s entries)\n' \
+    "$RECIPIENTS_YAML" "$count"
+fi
 exit $fail


### PR DESCRIPTION
## Summary

Two security improvements to the recipients stack:

1. **Multi-recipient age escrow activated** (commit 2992737) — `.chezmoi.yaml.tmpl recipients:` now lists both the DevPod primary key and an operator-supplied escrow pubkey on non-DevPod hardware (per NIST SP 800-57 §5.5.2). `docs/AUTHORIZED-HOSTS.md` macbook row flipped from `OPERATOR-FILL pending` to `active` with a real pubkey. Closes the deferred DOT-02 deliverable.

2. **`.age-recipients.yaml` as canonical SoT** (commit df3f3cf) — the hardcoded `age1...` strings inside `.chezmoi.yaml.tmpl` left no in-file pointer back to which host owned which key. New canonical YAML carries `name + role + pubkey` per entry (rotation diffs now show `name: macbook-escrow` changed pubkey instead of opaque substring churn). `.chezmoi.yaml.tmpl` reads it via `include + fromYaml`. `scripts/verify-recipients.sh` rewritten to compare `.age-recipients.yaml::active[].pubkey` against `docs/AUTHORIZED-HOSTS.md` active tier via yq + the locked awk indices ($4 pubkey, $8 tag).

Also adds a fail-loud guard at chezmoi boot when host signals conflict (e.g. `DEVPOD=1` set on darwin, or `IOS=1` set on non-linux) — chosen over warn-and-proceed because the ambiguity is operator misconfiguration that should surface before chezmoi mutates state.

## Files changed

- **NEW** `.age-recipients.yaml` — canonical SoT for active recipients
- **MOD** `.chezmoi.yaml.tmpl` — recipients block sourced via `include + fromYaml`; conflicting-host-signal guard
- **MOD** `scripts/verify-recipients.sh` — yq-based bidirectional `comm` diff between SoT and `AUTHORIZED-HOSTS.md`; `DOTFILES_REPO` + `RECIPIENTS_YAML` env overrides for tests
- **MOD** `docs/AUTHORIZED-HOSTS.md` — macbook row activated with real pubkey

## Test plan

- [ ] `bash scripts/verify-recipients.sh` exits 0 against the new SoT
- [ ] `chezmoi execute-template < .chezmoi.yaml.tmpl | yq -e '.age.recipients | length == 2'` exits 0
- [ ] Conflicting host signal triggers fail-loud (e.g. `DEVPOD=1 chezmoi execute-template` on darwin)
- [ ] shellcheck `scripts/verify-recipients.sh` clean