### PR TITLE
v2.2 Phase 15.1: add devpod-secondary age recipient (escrow follow-up)

### DIFF
--- a/.age-recipients.yaml
+++ b/.age-recipients.yaml
@@ -28,3 +28,6 @@ active:
   - name: macbook-escrow
     role: NIST-SP-800-57-physically-separate
     pubkey: age1kre65j3v87d0cru8tkj6g6s2823yncw78qcvu6y2m7h8umxxny6qpupzvq
+  - name: devpod-secondary
+    role: secondary-escrow
+    pubkey: age1jzz8f3q4pgntfenjlrg5kjvyladcplnah0w88f7cvxkryy49jfvqc86903

--- a/docs/AUTHORIZED-HOSTS.md
+++ b/docs/AUTHORIZED-HOSTS.md
@@ -17,6 +17,7 @@ The invariant is enforced bidirectionally by `scripts/verify-recipients.sh` — 
 |----------|------|--------|-------------|-------------|-----------|-----|
 | devpod | primary | age1wa2cuua5lfj26he6qrjrywdvqk3twvyhevfngfzy76ztxj5ex3xs454cgp | xs454cgp | 2026-05-04 | DevPod | active |
 | macbook | escrow | age1kre65j3v87d0cru8tkj6g6s2823yncw78qcvu6y2m7h8umxxny6qpupzvq | 6qpupzvq | 2026-05-04 | macOS | active |
+| devpod-secondary | secondary-escrow | age1jzz8f3q4pgntfenjlrg5kjvyladcplnah0w88f7cvxkryy49jfvqc86903 | qc86903 | 2026-05-07 | DevPod | active |
 
 ## Retired Hosts (kept for audit trail; NOT compared by verify script)
 


### PR DESCRIPTION
## Summary

**v2.2 Phase 15.1 (Sync Transport Hardening): devpod-secondary age key escrow**

Adds `devpod-secondary` recipient to the age-encryption escrow recipient list, completing the ADR-sec-02 Variant D follow-up from vault-ai Phase 15.1.

The new recipient covers the DevPod-side secondary identity whose age key was generated 2026-05-06 in `/home/vscode/.config/age/key.txt` during vault-ai Phase 15-03. Public key:

```
age1jzz8f3q4pgntfenjlrg5kjvyladcplnah0w88f7cvxkryy49jfvqc86903
```

## Changes

`641ebc1` — `feat(15.1-04): add devpod-secondary public key to escrow recipient list`

Both source-of-truth files updated atomically to preserve the bidirectional invariant enforced by `scripts/verify-recipients.sh`:

- `.age-recipients.yaml::active[].pubkey` — new `devpod-secondary` entry
- `docs/AUTHORIZED-HOSTS.md` Active Hosts table — matching row

## Coupled cross-repo PRs

- **vault-ai PR #17** — Phase 15 + 15.1 implementation (vault-init.sh, supervisord wiring, runbooks, rebuild-survival harness)
- **workspace-meta PR #22** — Phase 15 + 15.1 planning artefacts (`.planning/` metadata for both phases)

All three PRs must merge for v2.2 Phase 15+15.1 to be operationally complete.

## Verification

- [x] `verify-recipients.sh` exit 0 on local run (3 entries match)
- [x] Atomic invariant satisfied (both SoT files in single commit)
- [x] Zero AI attribution in commit
- [ ] **Operator post-merge:** `chezmoi apply` on Mac to propagate updated recipient list into the macbook escrow envelope
- [ ] **Operator post-merge:** Round-trip verify on DevPod via `age --decrypt --identity ~/.config/age/key.txt < <existing-secret>.age`

## Process notes

This PR exists to remediate a previous-session error where `641ebc1` was pushed directly to `main` instead of routed through PR review. The commit itself stands as authored — backed up at tag `backup/main-pre-reset-2026-05-08` before `main` was reset to `40928df` (Phase 14 PR #9 merge) and the commit re-routed onto this feature branch.

No content changes; pure history-routing fix.
