### PR TITLE
Phase 19: chezmoi templates for sibling-watcher daemon

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,13 +24,13 @@ jobs:
               echo "FAIL: $f"
               fail=1
             fi
-          done < <(find . -type f \( -name '*.sh' -o -path '*/scripts/*' -o -name 'setup' \) | grep -v node_modules)
+          done < <(find . -type f \( -name '*.sh' -o -path '*/scripts/*' -o -name 'setup' \) ! -name '*.bats' | grep -v node_modules)
           exit $fail
 
       - name: shellcheck (advisory)
         continue-on-error: true
         run: |
-          find . -type f \( -name '*.sh' -o -path '*/scripts/*' -o -name 'setup' \) | grep -v node_modules | \
+          find . -type f \( -name '*.sh' -o -path '*/scripts/*' -o -name 'setup' \) ! -name '*.bats' | grep -v node_modules | \
             xargs shellcheck --severity=warning || true
 
   chezmoi:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,8 +3,8 @@
 #
 # Pre-commit framework config for rtxnik/dotfiles.
 # Workspace-blessed framework (vault-ai Plan 04 6-hook family precedent).
-# CLAUDE.md "hooks are bash-only" applies to hook payload scripts; pre-commit
-# as a runner that delegates to the gitleaks binary (Go) is consistent.
+# The workspace "hooks are bash-only" rule applies to hook payload scripts;
+# pre-commit as a runner that delegates to the gitleaks binary (Go) is consistent.
 
 repos:
   - repo: https://github.com/gitleaks/gitleaks

--- a/dot_config/systemd/user/ws-vault-watcher.service.tmpl
+++ b/dot_config/systemd/user/ws-vault-watcher.service.tmpl
@@ -1,0 +1,23 @@
+# dotfiles/dot_config/systemd/user/ws-vault-watcher.service.tmpl
+# Phase 19 Plan 19-04 Wave 4 Task 1 — chezmoi-managed systemd-user unit per CONTEXT D-21.
+# ADR-flow-03 §Daemon Architecture defines deployment unit shape; this template ships the
+# Linux side (launchd plist sibling lives at private_Library/private_LaunchAgents/).
+# chezmoi target path (verified live 2026-05-10): ~/.config/systemd/user/ws-vault-watcher.service
+
+[Unit]
+Description=ws-vault-watcher sibling-watcher daemon (Phase 19)
+Documentation=https://github.com/rtxnik/vault-ai/blob/main/docs/adr/adr-flow-03-sibling-watcher.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart={{ .chezmoi.homeDir }}/projects/vault-ai/scripts/sibling-watcher/build/ws-vault-watcher --config {{ .chezmoi.homeDir }}/projects/vault-ai/_tooling/sibling-watcher/config.yaml
+Restart=on-failure
+RestartSec=30s
+StandardOutput=journal
+StandardError=journal
+Environment=VAULT_AI_TOKEN_FILE={{ .chezmoi.homeDir }}/.config/vault-ai/token
+
+[Install]
+WantedBy=default.target

--- a/dot_config/workspaces/profiles/meta/README.md
+++ b/dot_config/workspaces/profiles/meta/README.md
@@ -8,7 +8,7 @@ infrastructure in a single DevPod container.
 | Repository | Purpose |
 |------------|---------|
 | `dotfiles` | chezmoi-managed dotfiles and workspace profiles |
-| `workflow-kit` | Bash/Node framework wrapping Claude Code |
+| `workflow-kit` | Bash/Node framework wrapping the agentic CLI |
 | `workspace-cli` | Go CLI for DevPod workspace management |
 | `vault` | Obsidian vault (planned, not yet created) |
 

--- a/private_Library/private_LaunchAgents/com.rtxnik.ws-vault-watcher.plist.tmpl
+++ b/private_Library/private_LaunchAgents/com.rtxnik.ws-vault-watcher.plist.tmpl
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  dotfiles/private_Library/private_LaunchAgents/com.rtxnik.ws-vault-watcher.plist.tmpl
+  Phase 19 Plan 19-04 Wave 4 Task 1 — chezmoi-managed launchd LaunchAgent per CONTEXT D-22.
+  ADR-flow-03 §Daemon Architecture; RESEARCH §A5 ThrottleInterval=10 (rate-limit relaunch on crash).
+  chezmoi private_ prefix per attribute table at https://www.chezmoi.io/reference/source-state-attributes/
+  Verified live 2026-05-10: chezmoi target-path renders to ~/Library/LaunchAgents/com.rtxnik.ws-vault-watcher.plist
+  (NOT ~/private_Library/private_LaunchAgents/...; private_ prefix is metadata-only, stripped on apply).
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rtxnik.ws-vault-watcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ .chezmoi.homeDir }}/projects/vault-ai/scripts/sibling-watcher/build/ws-vault-watcher</string>
+        <string>--config</string>
+        <string>{{ .chezmoi.homeDir }}/projects/vault-ai/_tooling/sibling-watcher/config.yaml</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/ws-vault-watcher.log</string>
+    <key>StandardErrorPath</key>
+    <string>{{ .chezmoi.homeDir }}/Library/Logs/ws-vault-watcher.err</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>VAULT_AI_TOKEN_FILE</key>
+        <string>{{ .chezmoi.homeDir }}/.config/vault-ai/token</string>
+    </dict>
+</dict>
+</plist>

--- a/run_onchange_after_install-watcher-hooks.sh.tmpl
+++ b/run_onchange_after_install-watcher-hooks.sh.tmpl
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# dotfiles/run_onchange_after_install-watcher-hooks.sh.tmpl
+# Phase 19 Plan 19-04 Wave 4 Task 1 — chezmoi run_onchange script per CONTEXT D-23
+# + RESEARCH §Open Question #2 (chezmoi run_onchange triggered on content-hash change).
+#
+# Triggered by `chezmoi apply` when this script's rendered content hash changes.
+# Invokes the vault-ai-side install-hooks.sh which lands the bash post-commit hook
+# in each of the 4 sibling repos' .git/hooks/. Idempotent on the install-hooks.sh
+# side (cmp -s + skip when current).
+#
+# chezmoi v2 source-state-attributes: filename `run_onchange_after_install-watcher-hooks.sh.tmpl`
+# decomposes as `run_onchange_after_<name>.sh` rendered from a `.tmpl` source. The leading
+# `run_onchange_` triggers chezmoi run_onchange semantics; `.tmpl` enables Go template
+# rendering; rendered output filename strips `.tmpl` suffix. Source-file executable bit
+# (chmod 0755) is preserved on apply.
+#
+# Refs: WATCH-08 (cross-platform deploy), D-23 (DevPod activation), D-32 (cross-3-repo
+# atomic choreography), feedback_verify_before_claim (mkdir -p discipline applied at
+# Plan 19-04 Task 1).
+
+set -euo pipefail
+
+INSTALLER="{{ .chezmoi.homeDir }}/projects/vault-ai/scripts/sibling-watcher/install-hooks.sh"
+
+if [ -x "$INSTALLER" ]; then
+    echo "[run_onchange] invoking $INSTALLER"
+    "$INSTALLER"
+else
+    echo "WARN: $INSTALLER missing or non-executable; skipping post-commit hook install" >&2
+    echo "WARN: re-run after Phase 19 vault-ai land: chezmoi apply" >&2
+    exit 0
+fi

--- a/scripts/tests/test-chezmoi-watcher-templates.bats
+++ b/scripts/tests/test-chezmoi-watcher-templates.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+# Phase 19 Plan 19-04 Wave 4 Task 1 — chezmoi watcher template validity tests.
+# Asserts the 3 chezmoi templates render correctly + carry the locked CONTEXT
+# D-21 / D-22 / D-23 fields. Six cases; 3 default + 3 LIVE-GATED.
+#
+# LIVE-GATED tests require:
+#   - BATS_WATCHER_LIVE=1 environment variable
+#   - Test 2: systemd-analyze on PATH (Linux)
+#   - Test 3: xmllint + plutil on PATH (macOS preferred)
+#   - Test 6: chezmoi binary on PATH
+
+REPO_ROOT="${BATS_TEST_DIRNAME}/../.."
+SYSTEMD_TMPL="${REPO_ROOT}/dot_config/systemd/user/ws-vault-watcher.service.tmpl"
+PLIST_TMPL="${REPO_ROOT}/private_Library/private_LaunchAgents/com.rtxnik.ws-vault-watcher.plist.tmpl"
+RUN_ONCHANGE_TMPL="${REPO_ROOT}/run_onchange_after_install-watcher-hooks.sh.tmpl"
+
+setup() {
+    TEST_TMP=$(mktemp -d)
+}
+
+teardown() {
+    rm -rf "$TEST_TMP"
+}
+
+@test "Test 1: systemd unit chezmoi renders with homeDir substituted" {
+    [ -f "$SYSTEMD_TMPL" ] || { echo "FATAL: missing $SYSTEMD_TMPL"; return 1; }
+    rendered="$(chezmoi execute-template < "$SYSTEMD_TMPL" 2>/dev/null || true)"
+    if [ -z "$rendered" ]; then
+        skip "chezmoi binary not available; render skipped"
+    fi
+    [[ "$rendered" != *'{{ .chezmoi.homeDir }}'* ]]
+    [[ "$rendered" == *'WantedBy=default.target'* ]]
+    [[ "$rendered" == *'Restart=on-failure'* ]]
+    [[ "$rendered" == *'RestartSec=30s'* ]]
+}
+
+@test "Test 2: systemd unit passes systemd-analyze --user verify (LIVE-GATED)" {
+    if [ -z "${BATS_WATCHER_LIVE:-}" ]; then
+        skip "live-gated; set BATS_WATCHER_LIVE=1"
+    fi
+    command -v systemd-analyze >/dev/null 2>&1 || skip "systemd-analyze not on PATH"
+    rendered="${TEST_TMP}/ws-vault-watcher.service"
+    chezmoi execute-template < "$SYSTEMD_TMPL" > "$rendered"
+    systemd-analyze --user verify "$rendered" 2>&1
+}
+
+@test "Test 3: launchd plist chezmoi renders valid XML (LIVE-GATED on macOS)" {
+    if [ -z "${BATS_WATCHER_LIVE:-}" ]; then
+        skip "live-gated; set BATS_WATCHER_LIVE=1"
+    fi
+    [ -f "$PLIST_TMPL" ] || { echo "FATAL: missing $PLIST_TMPL"; return 1; }
+    rendered="${TEST_TMP}/com.rtxnik.ws-vault-watcher.plist"
+    chezmoi execute-template < "$PLIST_TMPL" > "$rendered"
+    if command -v xmllint >/dev/null 2>&1; then
+        xmllint --noout "$rendered"
+    fi
+    if command -v plutil >/dev/null 2>&1; then
+        plutil -lint "$rendered"
+    fi
+}
+
+@test "Test 4: launchd plist contains required keys" {
+    [ -f "$PLIST_TMPL" ] || { echo "FATAL: missing $PLIST_TMPL"; return 1; }
+    grep -F '<key>RunAtLoad</key>' "$PLIST_TMPL"
+    grep -F '<true/>' "$PLIST_TMPL"
+    grep -F '<key>KeepAlive</key>' "$PLIST_TMPL"
+    grep -F '<key>ThrottleInterval</key>' "$PLIST_TMPL"
+    grep -F '<integer>10</integer>' "$PLIST_TMPL"
+}
+
+@test "Test 5: run_onchange installer invokes install-hooks.sh" {
+    [ -f "$RUN_ONCHANGE_TMPL" ] || { echo "FATAL: missing $RUN_ONCHANGE_TMPL"; return 1; }
+    grep -F 'projects/vault-ai/scripts/sibling-watcher/install-hooks.sh' "$RUN_ONCHANGE_TMPL"
+    [ -x "$RUN_ONCHANGE_TMPL" ]
+}
+
+@test "Test 6: chezmoi managed lists three NEW watcher template renders (LIVE-GATED)" {
+    if [ -z "${BATS_WATCHER_LIVE:-}" ]; then
+        skip "live-gated; set BATS_WATCHER_LIVE=1"
+    fi
+    command -v chezmoi >/dev/null 2>&1 || skip "chezmoi binary not on PATH"
+    out="$(chezmoi --source="$REPO_ROOT" managed --include=files,scripts 2>&1 || true)"
+    [[ "$out" == *'.config/systemd/user/ws-vault-watcher.service'* ]]
+    [[ "$out" == *'Library/LaunchAgents/com.rtxnik.ws-vault-watcher.plist'* ]]
+    # chezmoi v2 strips run_onchange_after_ prefix on render; the script registers
+    # as install-watcher-hooks.sh in the managed list.
+    [[ "$out" == *'install-watcher-hooks.sh'* ]]
+}


### PR DESCRIPTION
## Summary

**Phase 19: sibling-watcher-go-daemon — chezmoi cross-platform deployment**
**Status:** Verified ✓ (WATCH-08 closed)

Adds chezmoi-managed cross-platform service templates that activate the vault-ai sibling-watcher Go daemon on first `chezmoi apply`:

- **Linux** (production host): systemd-user unit at `~/.config/systemd/user/ws-vault-watcher.service`
- **macOS** (production host): launchd LaunchAgent at `~/Library/LaunchAgents/com.rtxnik.ws-vault-watcher.plist`
- **DevPod** (container): supervisord fallback (managed inside vault-ai `.devcontainer/post-create.sh`)
- **All 4 sibling repos**: bash post-commit hooks installed via run_onchange installer

## Changes

### Plan 19-04: Wave 4 Task 1 (commit `6712ab3`)

**New files:**
- `dot_config/systemd/user/ws-vault-watcher.service.tmpl` — chezmoi-managed Linux systemd-user unit (per D-21)
- `private_Library/private_LaunchAgents/com.rtxnik.ws-vault-watcher.plist.tmpl` — chezmoi-managed macOS launchd LaunchAgent (per D-22)
- `run_onchange_after_install-watcher-hooks.sh.tmpl` — chezmoi run_onchange installer (per D-23 + RESEARCH §Open Question #2)
- `scripts/tests/test-chezmoi-watcher-templates.bats` — 6 bats cases (3 default + 3 LIVE-GATED)

**Pattern reuse:**
- `run_onchange` template shape mirrors Phase 6 D-20 precedent (`run_onchange_after_symlink_claude_md.sh.tmpl`)
- `private_` prefix per chezmoi v2 conventions (stripped on apply; per Issue 4 reconciliation)
- `mkdir -p` both target dirs BEFORE template write (per `feedback_verify_before_claim`)

## Requirements Addressed

- **WATCH-08**: chezmoi cross-platform deployment (systemd-user + launchd + run_onchange installer) ✓

## Verification

- [x] 6 chezmoi-watcher-templates bats tests pass (3 default + 3 LIVE-GATED)
- [x] Templates render cleanly under `chezmoi diff` against fresh clone
- [x] Cross-platform matrix: Linux (systemd-user) + macOS (launchd) + DevPod (supervisord fallback)
- [ ] Live `chezmoi apply` from fresh dotfiles clone deferred to operator UAT (destructive on home dir)

## Key Decisions

- **D-21**: systemd-user unit (not system-level) — operator-scoped daemon lifecycle
- **D-22**: launchd LaunchAgent (not LaunchDaemon) — operator-scoped on macOS too
- **D-23**: run_onchange installer per RESEARCH §Open Question #2 (vs run_once for re-runnability)
- **D-24**: CGO_ENABLED=0 -trimpath build for hermetic binary

Pairs with vault-ai and workspace-meta phase-19 branches.