### PR TITLE
chore(chezmoi): exclude BWS state cache from chezmoi-managed dir (ADR-sec-05 §M2)

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -1,0 +1,20 @@
+# .chezmoiignore -- paths chezmoi must NEVER copy from source to target.
+#
+# Format: gitignore-style globs.  Each entry references the chezmoi source path
+# (which mirrors the target home-directory path with a `dot_` prefix on hidden
+# entries).  Comments document the invariant being preserved and link the
+# binding contract.
+
+# --------------------------------------------------------------------------
+# BWS state cache (ADR-sec-05 §M2 backup-exclusion invariant)
+# --------------------------------------------------------------------------
+# The Bitwarden Secrets Manager CLI maintains an encrypted auth-handshake cache
+# at ~/.config/bws/state/ to reduce rate-limit pressure.  Per ADR-sec-05 §M2,
+# the cache must NOT be backed up or carried across machines:
+#   - Cache contents are encrypted under a key derived from BWS_ACCESS_TOKEN.
+#     After a token rotation (ADR-sec-05 §M3), the old cache is unusable
+#     under the new derived key -- restoring it from backup yields garbage.
+#   - State rehydrates lazily from server on first call after restore (§M5).
+#
+# Binding contract: vault-ai/docs/adr/adr-sec-05-bws-replaces-1password.md §M2.
+dot_config/bws/state


### PR DESCRIPTION
## Summary

Companion to [vault-ai #24](https://github.com/rtxnik/vault-ai/pull/24) and [workspace-meta #27](https://github.com/rtxnik/workspace-meta/pull/27) which superseded ADR-sec-02 Layer 3 (1Password CLI, paper-only) with BWS (Bitwarden Secrets Manager).

This PR adds the dotfiles-side enforcement of ADR-sec-05 §M2: the BWS state-cache directory must NEVER be backed up or carried across machines (cache is keyed to `BWS_ACCESS_TOKEN`; restoring after a rotation yields garbage).

## Changes

- **NEW** `.chezmoiignore` (20 lines) — first `.chezmoiignore` in the repo; excludes `dot_config/bws/state` from chezmoi-managed paths per the §M2 invariant. Documents the binding contract back to `vault-ai/docs/adr/adr-sec-05-bws-replaces-1password.md`.

## Verification

- [x] Rebased onto current `main` (clean 1-commit diff: +20 LOC)
- [x] No secrets, no AI references — passes pre-push gates
- [x] Mirrors the §M2 contract verbatim; no behavioural change for any consumer that was not already running BWS

## Related

- vault-ai #24 — supersession ADR (merged)
- workspace-meta #27 — sec-05 companion docs (merged)
- workspace-meta #28 — Phase 21 hardening/DR/cost-tracker (open)