### PR TITLE
feat: transparent UDP/QUIC via TPROXY + verified proxy image build

### DIFF
--- a/dot_config/workspaces/profiles/proxy/Dockerfile
+++ b/dot_config/workspaces/profiles/proxy/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && curl -fsSL \
        "https://github.com/XTLS/Xray-core/releases/download/${XRAY_VERSION}/Xray-linux-${XRAY_ARCH}.zip.dgst" \
        -o /tmp/xray.zip.dgst \
-    && EXPECT=$(grep -i 'sha2-256' /tmp/xray.zip.dgst | head -1 | awk '{print $NF}') \
+    && EXPECT=$(grep -ioE 'sha2-256[^0-9a-f]*[0-9a-f]{64}' /tmp/xray.zip.dgst | grep -oiE '[0-9a-f]{64}' | head -1) \
     && ACTUAL=$(sha256sum /tmp/xray.zip | awk '{print $1}') \
     && [ -n "$EXPECT" ] && [ "$EXPECT" = "$ACTUAL" ] \
        || { echo "xray-core checksum mismatch: expected=$EXPECT actual=$ACTUAL" >&2; exit 1; } \

--- a/dot_config/workspaces/profiles/proxy/Dockerfile
+++ b/dot_config/workspaces/profiles/proxy/Dockerfile
@@ -16,10 +16,17 @@ RUN apt-get update \
     && curl -fsSL \
        "https://github.com/XTLS/Xray-core/releases/download/${XRAY_VERSION}/Xray-linux-${XRAY_ARCH}.zip" \
        -o /tmp/xray.zip \
+    && curl -fsSL \
+       "https://github.com/XTLS/Xray-core/releases/download/${XRAY_VERSION}/Xray-linux-${XRAY_ARCH}.zip.dgst" \
+       -o /tmp/xray.zip.dgst \
+    && EXPECT=$(grep -i 'sha2-256' /tmp/xray.zip.dgst | head -1 | awk '{print $NF}') \
+    && ACTUAL=$(sha256sum /tmp/xray.zip | awk '{print $1}') \
+    && [ -n "$EXPECT" ] && [ "$EXPECT" = "$ACTUAL" ] \
+       || { echo "xray-core checksum mismatch: expected=$EXPECT actual=$ACTUAL" >&2; exit 1; } \
     && unzip /tmp/xray.zip -d /tmp/xray \
     && mv /tmp/xray/xray /usr/local/bin/xray \
     && chmod +x /usr/local/bin/xray \
-    && rm -rf /tmp/xray /tmp/xray.zip
+    && rm -rf /tmp/xray /tmp/xray.zip /tmp/xray.zip.dgst
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/dot_config/workspaces/profiles/proxy/entrypoint.sh
+++ b/dot_config/workspaces/profiles/proxy/entrypoint.sh
@@ -1,63 +1,53 @@
 #!/usr/bin/env bash
 # =============================================================================
-# Transparent proxy entrypoint
-# Sets up iptables NAT rules and starts xray as the xray user
+# Transparent proxy entrypoint (hybrid TPROXY)
+#  - dev-container (forwarded) traffic : mangle PREROUTING TPROXY (tcp + udp)
+#  - proxy's own egress (healthcheck)  : nat OUTPUT REDIRECT (tcp), uid xray bypassed
+# Fail-closed: TPROXY to a non-listening xray drops; 'direct' outbound is private-only.
 # =============================================================================
-
 set -euo pipefail
 
-# --- iptables NAT rules ---
-#
-# On container restart Docker reuses the network namespace, so any rules
-# from the previous run persist. Clean up before re-applying to keep the
-# entrypoint idempotent (otherwise `-N XRAY` fails with "Chain already
-# exists" and `set -e` aborts the whole startup).
+MARK=1
+TABLE=100
+PORT=12345
+PRIVATE=(10.0.0.0/8 172.16.0.0/12 192.168.0.0/16 127.0.0.0/8 169.254.0.0/16 224.0.0.0/4)
 
-# Detach XRAY from OUTPUT/PREROUTING if previously attached, then flush
-# and drop the chain so we can recreate it from scratch.
-while iptables -t nat -D OUTPUT -j XRAY 2>/dev/null; do :; done
-while iptables -t nat -D PREROUTING -j XRAY 2>/dev/null; do :; done
-iptables -t nat -D OUTPUT -p tcp -m owner --uid-owner xray -j RETURN 2>/dev/null || true
-iptables -t nat -D OUTPUT -p udp -m owner --uid-owner xray -j RETURN 2>/dev/null || true
-iptables -t nat -F XRAY 2>/dev/null || true
-iptables -t nat -X XRAY 2>/dev/null || true
+# --- idempotent cleanup (Docker reuses the netns across restarts) ---
+while iptables -t mangle -D PREROUTING -j XRAY 2>/dev/null; do :; done
+while iptables -t nat    -D OUTPUT    -j XRAY_OUT 2>/dev/null; do :; done
+iptables -t mangle -F XRAY 2>/dev/null || true; iptables -t mangle -X XRAY 2>/dev/null || true
+iptables -t nat    -F XRAY_OUT 2>/dev/null || true; iptables -t nat -X XRAY_OUT 2>/dev/null || true
+ip rule del fwmark $MARK lookup $TABLE 2>/dev/null || true
+ip route flush table $TABLE 2>/dev/null || true
 
-iptables -t nat -N XRAY
+# --- policy routing: deliver marked, foreign-destined packets to the local TPROXY socket ---
+ip rule add fwmark $MARK lookup $TABLE
+ip route add local default dev lo table $TABLE
 
-# Skip private networks (direct connection)
-iptables -t nat -A XRAY -d 10.0.0.0/8 -j RETURN
-iptables -t nat -A XRAY -d 172.16.0.0/12 -j RETURN
-iptables -t nat -A XRAY -d 192.168.0.0/16 -j RETURN
-iptables -t nat -A XRAY -d 127.0.0.0/8 -j RETURN
+# --- mangle PREROUTING: TPROXY forwarded dev-container traffic ---
+iptables -t mangle -N XRAY
+for net in "${PRIVATE[@]}"; do iptables -t mangle -A XRAY -d "$net" -j RETURN; done
+iptables -t mangle -A XRAY -p tcp -j TPROXY --on-port $PORT --tproxy-mark $MARK
+iptables -t mangle -A XRAY -p udp -j TPROXY --on-port $PORT --tproxy-mark $MARK
+iptables -t mangle -A PREROUTING -j XRAY
 
-# Redirect all remaining TCP and UDP to xray dokodemo-door
-iptables -t nat -A XRAY -p tcp -j REDIRECT --to-ports 12345
-iptables -t nat -A XRAY -p udp -j REDIRECT --to-ports 12345
+# --- nat OUTPUT: REDIRECT the proxy's OWN tcp egress (healthcheck), skip xray's tunnel ---
+iptables -t nat -N XRAY_OUT
+iptables -t nat -A XRAY_OUT -m owner --uid-owner xray -j RETURN
+for net in "${PRIVATE[@]}"; do iptables -t nat -A XRAY_OUT -d "$net" -j RETURN; done
+iptables -t nat -A XRAY_OUT -p tcp -j REDIRECT --to-ports $PORT
+iptables -t nat -A OUTPUT -p tcp -j XRAY_OUT
 
-# Apply to OUTPUT for proxy's own traffic (skip xray user to prevent loops)
-iptables -t nat -A OUTPUT -p tcp -m owner --uid-owner xray -j RETURN
-iptables -t nat -A OUTPUT -p udp -m owner --uid-owner xray -j RETURN
-iptables -t nat -A OUTPUT -j XRAY
+# --- verify ---
+iptables -t mangle -L XRAY -n >/dev/null 2>&1 && iptables -t nat -L XRAY_OUT -n >/dev/null 2>&1 \
+  && echo "iptables applied (mangle PREROUTING TPROXY + nat OUTPUT REDIRECT)" \
+  || { echo "ERROR: iptables rules failed to apply" >&2; exit 1; }
 
-# Apply to PREROUTING for traffic from workspace containers on bridge network
-iptables -t nat -A PREROUTING -j XRAY
-
-# Verify iptables rules were applied
-if iptables -t nat -L XRAY -n >/dev/null 2>&1; then
-    echo "iptables rules applied (OUTPUT + PREROUTING)"
-else
-    echo "ERROR: iptables rules failed to apply" >&2
-    exit 1
-fi
-
-# --- Start xray ---
-
-# Validate config before starting
+# --- validate + start xray ---
 if ! su -s /bin/sh xray -c "xray run -test -c /etc/xray/config.json" >/dev/null 2>&1; then
     echo "ERROR: xray config validation failed" >&2
     su -s /bin/sh xray -c "xray run -test -c /etc/xray/config.json" >&2
     exit 1
 fi
 echo "xray config validated"
-
 exec su -s /bin/sh xray -c "xray run -c /etc/xray/config.json"

--- a/dot_config/workspaces/profiles/proxy/entrypoint.sh
+++ b/dot_config/workspaces/profiles/proxy/entrypoint.sh
@@ -38,6 +38,13 @@ for net in "${PRIVATE[@]}"; do iptables -t nat -A XRAY_OUT -d "$net" -j RETURN; 
 iptables -t nat -A XRAY_OUT -p tcp -j REDIRECT --to-ports $PORT
 iptables -t nat -A OUTPUT -p tcp -j XRAY_OUT
 
+# --- IPv6: this transparent proxy is IPv4-only. Fail closed: drop forwarded
+#     IPv6 so dev-container v6 egress cannot leak around the v4 TPROXY capture.
+#     Guarded so a container without ip6tables still starts. ---
+if command -v ip6tables >/dev/null 2>&1; then
+    ip6tables -C FORWARD -j DROP 2>/dev/null || ip6tables -A FORWARD -j DROP || true
+fi
+
 # --- verify ---
 iptables -t mangle -L XRAY -n >/dev/null 2>&1 && iptables -t nat -L XRAY_OUT -n >/dev/null 2>&1 \
   && echo "iptables applied (mangle PREROUTING TPROXY + nat OUTPUT REDIRECT)" \

--- a/dot_config/workspaces/profiles/proxy/entrypoint.sh
+++ b/dot_config/workspaces/profiles/proxy/entrypoint.sh
@@ -27,6 +27,11 @@ ip route add local default dev lo table $TABLE
 # --- mangle PREROUTING: TPROXY forwarded dev-container traffic ---
 iptables -t mangle -N XRAY
 for net in "${PRIVATE[@]}"; do iptables -t mangle -A XRAY -d "$net" -j RETURN; done
+# Established flows already owned by a local transparent socket bypass re-TPROXY.
+# Guarded: if the xt_socket module is unavailable the rule is skipped and we fall
+# back to plain TPROXY (still correct), never aborting startup.
+iptables -t mangle -A XRAY -p tcp -m socket -j RETURN 2>/dev/null || true
+iptables -t mangle -A XRAY -p udp -m socket -j RETURN 2>/dev/null || true
 iptables -t mangle -A XRAY -p tcp -j TPROXY --on-port $PORT --tproxy-mark $MARK
 iptables -t mangle -A XRAY -p udp -j TPROXY --on-port $PORT --tproxy-mark $MARK
 iptables -t mangle -A PREROUTING -j XRAY
@@ -42,7 +47,7 @@ iptables -t nat -A OUTPUT -p tcp -j XRAY_OUT
 #     IPv6 so dev-container v6 egress cannot leak around the v4 TPROXY capture.
 #     Guarded so a container without ip6tables still starts. ---
 if command -v ip6tables >/dev/null 2>&1; then
-    ip6tables -C FORWARD -j DROP 2>/dev/null || ip6tables -A FORWARD -j DROP || true
+    ip6tables -C FORWARD -j DROP 2>/dev/null || ip6tables -I FORWARD -j DROP || true
 fi
 
 # --- verify ---


### PR DESCRIPTION
## Summary

- Fixes transparent UDP/QUIC egress for workspace dev containers. The proxy container moves from `nat REDIRECT` (which cannot recover the original UDP destination, so QUIC/UDP traffic leaked or broke) to a hybrid `mangle TPROXY` setup: forwarded container traffic is TPROXY'd (TCP+UDP) into xray's transparent inbound, while the proxy's own egress (healthcheck) stays on `nat OUTPUT REDIRECT`.
- **Fail-closed** posture: TPROXY to a non-listening socket drops when the tunnel is down; an IPv6 `FORWARD` drop belt prevents v6 traffic leaking around the v4-only capture; the `direct` outbound stays scoped to private networks; canonical `-m socket` RETURN (guarded) bypasses re-capture of established flows.
- **Supply chain**: the image build now verifies the xray-core release zip SHA-256 against the published `.dgst` before extraction, failing closed on mismatch (the pinned version stays `v26.2.6`).

> Companion to workspace-cli `feature/proxy-production`, which adds the inbound `sockopt.tproxy` these rules require, plus `ws proxy doctor` / `ws proxy test` / `ws proxy upgrade-config`. Apply both together and verify live via the operator runbook (`ws proxy doctor` green + `ws proxy test` distinct exit IP on a salamander endpoint).

## Change Log

- feat(proxy): hybrid TPROXY entrypoint for transparent UDP/QUIC
- fix(proxy): fail-closed IPv6 belt — drop forwarded v6 to prevent tunnel-bypass leak
- fix(proxy): verify xray-core release checksum in proxy image build
- fix(proxy): canonical TPROXY -m socket RETURN, v6 belt insert, anchored digest

## Test Plan

- [x] `bash -n entrypoint.sh` — clean
- [x] `shellcheck` — clean (one pre-accepted SC2015 info on the rule-verify idiom)
- [ ] Live operator verification — `ws proxy rebuild --force` (checksum-verified build), `ws proxy doctor` green, `ws proxy test` distinct exit IP; pending an operator run in a Docker environment

## Checklist

- [x] No secrets in diff
- [x] `bash -n` clean

## Risk & Rollback

- **Risk: medium.** Transparent-proxy iptables/TPROXY is host/kernel-dependent and can only be confirmed on a live container. Documented fallback in the companion runbook: revert the entrypoint to REDIRECT-TCP + leave UDP fail-closed if all-TPROXY misbehaves on the operator's kernel.
- **Rollback:** `git revert`; independent of the workspace-cli PR.
